### PR TITLE
Remove lock on sidekiq <7

### DIFF
--- a/wisper-sidekiq-compat.gemspec
+++ b/wisper-sidekiq-compat.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
   spec.add_dependency 'wisper-compat'
-  spec.add_dependency 'sidekiq', '>= 6.5', '< 7'
+  spec.add_dependency 'sidekiq', '>= 6.5'
 end


### PR DESCRIPTION
We want to be able to upgrade sidekiq. `wisper-sidekiq-compat` is currently locked to Sidekiq < 7, which blocks the update for Ons Agenda. removed the lock and used it in Agenda. So far i am not encountering issues, see https://github.com/nedap/Behandel-Ons/pull/9913.